### PR TITLE
5 feature content quiz 삭제 api 개발

### DIFF
--- a/src/main/java/com/example/oqp/common/error/ErrorCode.java
+++ b/src/main/java/com/example/oqp/common/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     CONTENT_NOT_FOUND_IMAGE(421, "썸네일이 없습니다."),
     QUIZ_IMAGE_OVER(422, "Quiz 이미지가 Quiz 보다 많습니다."),
     QUIZ_NOT_FOUND(423, "Quiz를 찾을 수 없습니다."),
+    CONTENT_QUIZ_NOT_SAME_ID(424, "콘텐츠에 포함되지 않은 퀴즈입니다."),
 
     DELETE_FAIL(430, "사용자 삭제에 실패하였습니다.");
 

--- a/src/main/java/com/example/oqp/content/controller/ContentController.java
+++ b/src/main/java/com/example/oqp/content/controller/ContentController.java
@@ -4,6 +4,8 @@ import com.example.oqp.common.error.response.ErrorResponse;
 import com.example.oqp.common.security.custom.CustomUserDetails;
 import com.example.oqp.content.controller.request.ContentAddRequest;
 import com.example.oqp.content.controller.request.ContentModifyRequest;
+import com.example.oqp.content.controller.request.ContentQuizDeleteRequest;
+import com.example.oqp.content.controller.response.ContentQuizDeleteResponse;
 import com.example.oqp.content.model.dto.ContentDto;
 import com.example.oqp.content.pagination.PaginationResponse;
 import com.example.oqp.content.service.ContentService;
@@ -118,6 +120,35 @@ public class ContentController {
         return ResponseEntity.ok(modify);
     }
 
+    @Operation(summary = "콘텐츠 & 퀴즈 삭제", description = "Content Id는 필수로 넣어줘야함", security = {
+            @SecurityRequirement(name = "Authorization")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공시 200 반환", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ContentQuizDeleteResponse.class))
+            }),
+            @ApiResponse(responseCode = "407", description = "사용자를 찾지 못할경우 407 반환", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            }),
+            @ApiResponse(responseCode = "408", description = "삭제할 콘텐츠와 유저가 같지 않을 경우 408 반환", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            }),
+            @ApiResponse(responseCode = "420", description = "콘텐츠를 삭제하지 못했을 경우 420 반환", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            }),
+            @ApiResponse(responseCode = "423", description = "퀴즈를 찾지 못했을 경우 423 반환", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            }),
+            @ApiResponse(responseCode = "424", description = "Quiz에 연결된 Content ID 가 다르면 424 반환")
+    })
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> delete(
+            @RequestBody @Valid ContentQuizDeleteRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        ContentQuizDeleteResponse delete = contentService.delete(request, customUserDetails);
 
+        return ResponseEntity.ok(delete);
+    }
 
 }

--- a/src/main/java/com/example/oqp/content/controller/request/ContentQuizDeleteRequest.java
+++ b/src/main/java/com/example/oqp/content/controller/request/ContentQuizDeleteRequest.java
@@ -1,0 +1,17 @@
+package com.example.oqp.content.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class ContentQuizDeleteRequest {
+    @NotNull
+    private Long contentId;
+
+    private Long quizId;
+}

--- a/src/main/java/com/example/oqp/content/controller/response/ContentQuizDeleteResponse.java
+++ b/src/main/java/com/example/oqp/content/controller/response/ContentQuizDeleteResponse.java
@@ -1,0 +1,15 @@
+package com.example.oqp.content.controller.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentQuizDeleteResponse {
+
+    private String contentDelete;
+
+    private String quizDelete;
+}

--- a/src/main/java/com/example/oqp/quiz/model/repository/QuizRepository.java
+++ b/src/main/java/com/example/oqp/quiz/model/repository/QuizRepository.java
@@ -4,4 +4,6 @@ import com.example.oqp.quiz.model.entity.QuizEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
+
+    void deleteByContentId(Long contentId);
 }


### PR DESCRIPTION
# ✨ [Feature] Content & Quiz 삭제 API 개발 

---

## 📋 개요 (Overview)
콘텐츠 & 퀴즈 삭제 API를 개발

---

## 📋 세부 요구 사항 (Detailed Requirements)
### **1. 주요 기능**
- **[콘텐츠 삭제]** : 콘텐츠 삭제 연관관계로 묶여진 퀴즈들도 같이 삭제됌
- **[퀴즈 삭제]** : 콘텐츠 안에 들어있는 퀴즈 삭제
- ...

---

## ✅ 체크리스트 (Checklist)
- [x] 콘텐츠 & 퀴즈 삭제 API 개발
- [x] API 테스트 및 디버깅

---

## 🛠 구현 사항 (What was implemented)
- 요청으로 Content id와 quiz id를 받고 콘텐츠 전체를 삭제할 경우 quiz id를 null로 설정하면 됌
- Content의 user_id와 인증된 사용자 id를 검증 통과시 삭제 처리
- quiz id가 있을 경우 Content 에 포함된 quiz인지 검증 후 quiz 삭제
- 응답으로 삭제 되었음을 알려줌 

---

## 🔗 관련 이슈 (Related Issue)
- 이 PR은 [Feature] Content & Quiz 삭제 API 개발 #5 이슈를 구현

---

## 💬 추가 메모 (Additional Notes)
- quizId는 null 이여도 괜찮지만 contentId는 null을 가져선 안됌
